### PR TITLE
Ensure os from all environment nodes is added to service role query.

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -155,9 +155,10 @@ end
 
 nagios_bags         = NagiosDataBags.new
 
-env_roles = ['linux']
+env_roles = []
 nodes.each do |n|
   Chef::Log.info "services_roles_filter_query :: #{n['roles']}"
+  env_roles << n['os']
   env_roles << n['roles']
 end
 


### PR DESCRIPTION
- Ensures all os's in an env are used during a search.
