### PR TITLE
pass node to data bag helper

### DIFF
--- a/recipes/server.rb
+++ b/recipes/server.rb
@@ -168,7 +168,8 @@ nodes.each do |n|
   hostgroups << n['os'] unless hostgroups.include?(n['os']) || n['os'].nil?
 end
 
-nagios_bags         = NagiosDataBags.new
+nagios_bags      = NagiosDataBags.new
+nagios_bags.node = node
 
 env_roles = []
 nodes.each do |n|


### PR DESCRIPTION
data bag helper needs to access the node to read platform and platform_version and to read the local services directory attribute.
